### PR TITLE
Resolve pyright issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,19 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
-### Dependencies
-* Updated to Sphinx>=8.1  (from Sphinx>=8.2)
-* Updated to sphinx-autodoc-typehints>=3.0  (from sphinx-autodoc-typehints>=3.1)
+-/-
+
+
+## [0.0.5] - 2025-03-20
+
+### Removed
+* src/plotly-stubs/__init__.pyi : removed import of plotly.version
 
 ### Dependencies
 * Updated to ruff>=0.11.0  (from ruff>=0.9.5)
 * Updated to pyright>=1.1.396  (from pyright>=1.1.393)
 * Updated to sourcery>=1.35  (from sourcery>=1.33)
-* Updated to Sphinx>=8.2  (from Sphinx>=8.1)
-* Updated to sphinx-autodoc-typehints>=3.1  (from sphinx-autodoc-typehints>=3.0)
 * Updated to pre-commit>=4.1  (from pre-commit>=4.0)
-
--/-
 
 
 ## [0.0.4] - 2025-02-18
@@ -40,8 +40,8 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 * Beta release 0.0.1
 
 <!-- Markdown link & img dfn's -->
-[unreleased]: https://github.com/ClaasRostock/plotly-stubs/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/ClaasRostock/plotly-stubs/releases/tag/v0.0.4...v0.1.0
+[unreleased]: https://github.com/ClaasRostock/plotly-stubs/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/ClaasRostock/plotly-stubs/releases/tag/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/ClaasRostock/plotly-stubs/releases/tag/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/ClaasRostock/plotly-stubs/releases/tag/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/ClaasRostock/plotly-stubs/releases/tag/v0.0.1...v0.0.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 title: plotly-stubs
-version: 0.0.4
+version: 0.0.5
 abstract: >-
     Type stubs for plotly.
 type: software

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ copyright = "2024, DNV AS. All rights reserved."
 author = "Claas Rostock, , "
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.4"
+release = "0.0.5"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [
 
 [project]
 name = "plotly-stubs"
-version = "0.0.4"
+version = "0.0.5"
 description = "Type stubs for plotly."
 readme = "README.md"
 requires-python = ">= 3.10, < 3.14"

--- a/src/plotly-stubs/__init__.pyi
+++ b/src/plotly-stubs/__init__.pyi
@@ -9,10 +9,8 @@ import plotly.offline as offline
 import plotly.tools as tools
 import plotly.utils as utils
 from plotly.graph_objs import Figure
-from plotly.version import __version__
 
 __all__ = [
-    "__version__",
     "colors",
     "data",
     "graph_objs",


### PR DESCRIPTION
src/plotly-stubs/__init__.pyi : removed import of plotly.version

## Summary by Sourcery

Removes the import of plotly.version from src/plotly-stubs/__init__.pyi.