### PR TITLE
Allow x and y to accept `Sequence[str]`, and hovertext to accept `Sequence[Sequence[str]]`

### DIFF
--- a/src/plotly-stubs/graph_objs/_heatmap.pyi
+++ b/src/plotly-stubs/graph_objs/_heatmap.pyi
@@ -1,6 +1,6 @@
 # pyright: reportPropertyTypeMismatch=false
 from collections.abc import Hashable, Sequence
-from typing import Any
+from typing import Any, TypeAlias
 
 import numpy as np
 import pandas as pd
@@ -12,6 +12,9 @@ from plotly.graph_objs.heatmap import (
     Stream,
     Textfont,
 )
+
+_AxisValueType: TypeAlias = int | float | str
+_HoverTextType: TypeAlias = _AxisValueType | Sequence[_AxisValueType] | Sequence[Sequence[_AxisValueType]]
 
 class Heatmap(_BaseTraceType):
     _parent_path_str = ...
@@ -82,11 +85,9 @@ class Heatmap(_BaseTraceType):
     @hovertemplatesrc.setter
     def hovertemplatesrc(self, val: str | None) -> None: ...
     @property
-    def hovertext(self) -> str | Sequence[str] | None: ...
+    def hovertext(self) -> _HoverTextType | None: ...
     @hovertext.setter
-    def hovertext(
-        self, val: str | float | Sequence[str] | Sequence[float] | np.ndarray[tuple[int, ...], np.dtype[np.float64]]
-    ) -> None: ...
+    def hovertext(self, val: _HoverTextType | np.ndarray[tuple[int, ...], np.dtype[np.float64]]) -> None: ...
     @property
     def hovertextsrc(self) -> str | None: ...
     @hovertextsrc.setter
@@ -349,13 +350,7 @@ class Heatmap(_BaseTraceType):
         | np.ndarray[tuple[int, ...], np.dtype[np.float64]]
         | None = ...,
         hovertemplatesrc: str | None = ...,
-        hovertext: str
-        | float
-        | Sequence[str]
-        | Sequence[Sequence[str]]
-        | Sequence[float]
-        | np.ndarray[tuple[int, ...], np.dtype[np.float64]]
-        | None = ...,
+        hovertext: _HoverTextType | np.ndarray[tuple[int, ...], np.dtype[np.float64]] | None = ...,
         hovertextsrc: str | None = ...,
         ids: Sequence[str] | np.ndarray[tuple[int, ...], np.dtype[np.str_]] | pd.Series[str] | None = ...,
         idssrc: str | None = ...,
@@ -385,12 +380,7 @@ class Heatmap(_BaseTraceType):
         uid: str | int | None = ...,
         uirevision: Hashable | None = ...,
         visible: bool | str | None = ...,
-        x: Sequence[int]
-        | Sequence[float]
-        | Sequence[str]
-        | np.ndarray[tuple[int, ...], np.dtype[np.float64]]
-        | pd.Series[float]
-        | None = ...,
+        x: _AxisValueType | np.ndarray[tuple[int, ...], np.dtype[np.float64]] | pd.Series[float] | None = ...,
         x0: int | float | None = ...,
         xaxis: str | None = ...,
         xcalendar: str | None = ...,
@@ -401,12 +391,7 @@ class Heatmap(_BaseTraceType):
         xperiodalignment: str | None = ...,
         xsrc: str | None = ...,
         xtype: str | None = ...,
-        y: Sequence[int]
-        | Sequence[float]
-        | Sequence[str]
-        | np.ndarray[tuple[int, ...], np.dtype[np.float64]]
-        | pd.Series[float]
-        | None = ...,
+        y: _AxisValueType | np.ndarray[tuple[int, ...], np.dtype[np.float64]] | pd.Series[float] | None = ...,
         y0: int | float | None = ...,
         yaxis: str | None = ...,
         ycalendar: str | None = ...,

--- a/src/plotly-stubs/graph_objs/_heatmap.pyi
+++ b/src/plotly-stubs/graph_objs/_heatmap.pyi
@@ -352,6 +352,7 @@ class Heatmap(_BaseTraceType):
         hovertext: str
         | float
         | Sequence[str]
+        | Sequence[Sequence[str]]
         | Sequence[float]
         | np.ndarray[tuple[int, ...], np.dtype[np.float64]]
         | None = ...,
@@ -386,6 +387,7 @@ class Heatmap(_BaseTraceType):
         visible: bool | str | None = ...,
         x: Sequence[int]
         | Sequence[float]
+        | Sequence[str]
         | np.ndarray[tuple[int, ...], np.dtype[np.float64]]
         | pd.Series[float]
         | None = ...,
@@ -401,6 +403,7 @@ class Heatmap(_BaseTraceType):
         xtype: str | None = ...,
         y: Sequence[int]
         | Sequence[float]
+        | Sequence[str]
         | np.ndarray[tuple[int, ...], np.dtype[np.float64]]
         | pd.Series[float]
         | None = ...,


### PR DESCRIPTION
See https://github.com/ClaasRostock/plotly-stubs/issues/15

## Summary by Sourcery

Extend Heatmap trace typing to support additional sequence-based inputs for axes and hover text.

New Features:
- Allow Heatmap.hovertext to be specified as a nested sequence of strings for per-cell annotations.
- Allow Heatmap.x and Heatmap.y to be specified as sequences of strings in addition to numeric sequences.